### PR TITLE
Add support for new safelink URLs introduced in Teams

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
 function removeSafelink(requestDetails) {
-  if (requestDetails.url.includes('safelinks.protection.outlook.com/')) {
+  if (requestDetails.url.includes('safelinks.protection.outlook.com/') ||
+      requestDetails.url.includes('statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html')) {
     var originalURL = getParameterByName('url', requestDetails.url);
 
     return {


### PR DESCRIPTION
Recently Microsoft has introduced safelinks to Teams. In contrast to outlook, they use a different URL:

https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html?url=...

With this small modification, links opened from within the Teams client will properly be redirecting to the original destination without the safelink service.