### PR TITLE
Limited permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,9 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "<all_urls>"
+    "https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html*",
+    "https://safelinks.protection.outlook.com/*",
+    "https://outlook.office.com/mail/safelink.html*"
   ],
   "icons": {
     "48": "icons/48x48.png",


### PR DESCRIPTION
Changed permissions so the plugin has only access to selected sites and not all. This way the plugin feels safer to use as the user does not need to grant wide permissions.