### PR TITLE
Making extension compatible with chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 web-ext-artifacts/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 web-ext-artifacts/
 node_modules/
+/browser-polyfill.min.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Compatibility with Chrome (#2, with help from @pataluc)
+
 ## [1.6.0] - 2023-05-01
 ### Added
 - Support for office365.us Safe Link domains (e.g. "usg01.safelinks.protection.office365.us") (#8)

--- a/README.md
+++ b/README.md
@@ -21,15 +21,7 @@ The page contains easy-to-follow steps on how to debug the redirects.
 ## How to package the addon
 
 1. Install `web-ext` (see [their GitHub README][web-ext])
-2. From your checkout, run the following:
-  
-  ```bash
-  web-ext build --ignore-files \
-    "icons/*.sh" \
-    "icons/*.svg" \
-    "test-page.html" \
-    "CHANGELOG.md"
-  ```
+2. From your checkout, run `./build.sh`
 
 ## Source code checklist (Firefox addon review)
 

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ npm install
 # Build the extension
 web-ext build --ignore-files \
   "node_modules/**" \
+  "package{,-lock}.json" \
   "icons/*.sh" \
   "icons/*.svg" \
   "test-page.html" \

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ npm install
 
 # Build the extension
 web-ext build --ignore-files \
+  "build.sh" \
   "node_modules/**" \
   "package{,-lock}.json" \
   "icons/*.sh" \

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install the dependencies
+npm install
+
 # Build the extension
 web-ext build --ignore-files \
   "icons/*.sh" \

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ npm install
 
 # Build the extension
 web-ext build --ignore-files \
+  "node_modules/**" \
   "icons/*.sh" \
   "icons/*.svg" \
   "test-page.html" \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Build the extension
+web-ext build --ignore-files \
+  "icons/*.sh" \
+  "icons/*.svg" \
+  "test-page.html" \
+  "CHANGELOG.md"

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
   },
   "background": {
     "scripts": [
+      "browser-polyfill.min.js",
       "background.js"
     ]
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "firefox-remove-safelinks",
+  "version": "1.6.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "firefox-remove-safelinks",
+      "version": "1.6.0",
+      "license": "MPL-2.0"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "firefox-remove-safelinks",
       "version": "1.6.0",
+      "hasInstallScript": true,
       "license": "MPL-2.0",
       "devDependencies": {
         "webextension-polyfill": "^0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,24 @@
     "": {
       "name": "firefox-remove-safelinks",
       "version": "1.6.0",
-      "license": "MPL-2.0"
+      "license": "MPL-2.0",
+      "devDependencies": {
+        "webextension-polyfill": "^0.10.0"
+      }
+    },
+    "node_modules/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "firefox-remove-safelinks",
+  "version": "1.6.0",
+  "description": "Firefox addon that detects when you open a \"Microsoft Safe Link\" and, instead of sending your data to Microsoft, it directly opens the original URL.",
+  "main": "background.js",
+  "scripts": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wtimme/firefox-remove-safelinks.git"
+  },
+  "author": "wtimme <wtimme@users.noreply.github.com>",
+  "license": "MPL-2.0",
+  "bugs": {
+    "url": "https://github.com/wtimme/firefox-remove-safelinks/issues"
+  },
+  "homepage": "https://github.com/wtimme/firefox-remove-safelinks#readme"
+}

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "bugs": {
     "url": "https://github.com/wtimme/firefox-remove-safelinks/issues"
   },
-  "homepage": "https://github.com/wtimme/firefox-remove-safelinks#readme"
+  "homepage": "https://github.com/wtimme/firefox-remove-safelinks#readme",
+  "devDependencies": {
+    "webextension-polyfill": "^0.10.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.6.0",
   "description": "Firefox addon that detects when you open a \"Microsoft Safe Link\" and, instead of sending your data to Microsoft, it directly opens the original URL.",
   "main": "background.js",
-  "scripts": {},
+  "scripts": {
+    "postinstall": "cp node_modules/webextension-polyfill/dist/browser-polyfill.min.js ."
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wtimme/firefox-remove-safelinks.git"


### PR DESCRIPTION
### Introduction

This little contribution aims to make the extension compatible with chrome, as suggested by @BoredGameGeek in the comments of #2 (https://github.com/wtimme/firefox-remove-safelinks/issues/2#issuecomment-1243708622)

The inclusion of browser-polyfills.js seems far from ideal, but i don't know if there's a better/cleaner/prettier way to do it.

### All Submissions:

* [X] Have you tested your changes with the `test-page.html` file?
* [X] Have you added a short summary to the `CHANGELOG.md`, or actively decided that it's not worth mentioning?
