### PR TITLE
Added options to only bypass allowed sites

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,13 +18,12 @@ function removeSafelink(requestDetails) {
 
   console.debug('Blocked a "Microsoft Safe Link" redirect.')
 
-  if ( allowedHosts.length == 0 || allowedHosts[0] == "" || allowedHosts.find((element) => originalURL.startsWith(element)) ) {
+  if (allowedHosts.length == 0 || allowedHosts[0] == "" || allowedHosts.find((element) => originalURL.startsWith(element))) {
     return {
       redirectUrl: originalURL
     };
-  }
-  else {
-    return ;
+  } else {
+    return;
   }
 }
 

--- a/background.js
+++ b/background.js
@@ -1,11 +1,31 @@
+// Initialize the list of allowed hosts
+let allowedHosts = [];
+
+// Get the stored list
+browser.storage.local.get(data => {
+  if (data.allowedHosts) {
+    allowedHosts = data.allowedHosts;
+  }
+});
+
+// Listen for changes in the allowed list
+browser.storage.onChanged.addListener(changeData => {
+  allowedHosts = changeData.allowedHosts.newValue;
+});
+
 function removeSafelink(requestDetails) {
   var originalURL = getParameterByName('url', requestDetails.url);
 
   console.debug('Blocked a "Microsoft Safe Link" redirect.')
 
-  return {
-    redirectUrl: originalURL
-  };
+  if ( allowedHosts.length == 0 || allowedHosts[0] == "" || allowedHosts.find((element) => originalURL.startsWith(element)) ) {
+    return {
+      redirectUrl: originalURL
+    };
+  }
+  else {
+    return ;
+  }
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/manifest.json
+++ b/manifest.json
@@ -5,9 +5,9 @@
   "version": "1.6.0",
   "homepage_url": "https://github.com/wtimme/firefox-remove-safelinks",
   "permissions": [
+    "storage",
     "webRequest",
     "webRequestBlocking",
-    "storage",
     "https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html*",
     "https://safelinks.protection.outlook.com/*",
     "https://*.safelinks.protection.outlook.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,7 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
+    "storage",
     "https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html*",
     "https://safelinks.protection.outlook.com/*",
     "https://*.safelinks.protection.outlook.com/*",
@@ -22,5 +23,8 @@
     "scripts": [
       "background.js"
     ]
+  },
+  "options_ui": {
+    "page": "options/options.html"
   }
 }

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,4 @@
+#allowed-hosts {
+  display: block;
+  margin-top: 1em;
+}

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="options.css"/>
+  </head>
+
+  <body>
+
+    <section>
+      <span class="title">Allowed sites</span>
+      <textarea id="allowed-hosts" rows="10" cols="50"></textarea>
+    </section>
+
+    <script src="options.js"></script>
+  </body>
+
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,25 @@
+const allowedHostsTextArea = document.querySelector("#allowed-hosts");
+
+// Store the currently selected settings using browser.storage.local.
+function storeSettings() {
+  let allowedHosts = allowedHostsTextArea.value.split("\n");
+  browser.storage.local.set({
+    allowedHosts
+  });
+}
+
+// Update the options UI with the settings values retrieved from storage,
+// or the default settings if the stored settings are empty.
+function updateUI(restoredSettings) {
+  allowedHostsTextArea.value = restoredSettings.allowedHosts.join("\n");
+}
+
+function onError(e) {
+  console.error(e);
+}
+
+// On opening the options page, fetch stored settings and update the UI with them.
+browser.storage.local.get().then(updateUI, onError);
+
+// Whenever the contents of the textarea changes, save the new values
+allowedHostsTextArea.addEventListener("change", storeSettings);


### PR DESCRIPTION
By default current behavior is maintained

### Introduction

This plugin is very powerful and it could be dangerous to bypassing the check for all sites.
Added Options page that allows configuring sites for which the check should be bypassed. The default behavior (empty list) defaults to current behavior of bypassing for all sites.
This is about the destination sites, not the Microsoft sites. So for example you may decide you trust https://github.com and https://google.com but execute Microsoft check for all others

### All Submissions:

* [x] Have you tested your changes with the `test-page.html` file?
* [x] Have you added a short summary to the `CHANGELOG.md`, or actively decided that it's not worth mentioning?
