### PR TITLE
Read hosts directly from permisions

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,19 +8,14 @@ function removeSafelink(requestDetails) {
   };
 }
 
-browser.webRequest.onBeforeRequest.addListener(
-  removeSafelink,
-  {
-    urls: [
-      "https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html*",
-      "https://safelinks.protection.outlook.com/*",
-      "https://*.safelinks.protection.outlook.com/*",
-      "https://outlook.office.com/mail/safelink.html*",
-      "https://*.safelinks.protection.office365.us/*",
-    ]
-  },
-  ['blocking']
-);
+browser.permissions.getAll().then((p) => {
+  browser.webRequest.onBeforeRequest.addListener(
+    removeSafelink, {
+      urls: p.origins
+    },
+    ['blocking']
+  );
+});
 
 // Source: https://stackoverflow.com/a/901144
 function getParameterByName(name, url) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,14 @@
 {
   "description": "Disables Microsoft SafeLink protection by redirecting to the original URL instead of going through Microsoft",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Disable Microsoft Safe Links",
   "version": "1.6.0",
   "homepage_url": "https://github.com/wtimme/firefox-remove-safelinks",
   "permissions": [
     "webRequest",
-    "webRequestBlocking",
+    "webRequestBlocking"
+  ],
+  "host_permissions": [
     "https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html*",
     "https://safelinks.protection.outlook.com/*",
     "https://*.safelinks.protection.outlook.com/*",


### PR DESCRIPTION
By default current behavior is maintained

### Introduction

Removes duplication, when adding new Microsoft site it is enough to add it in the manifest only.
Move to manifest v3 is required to easily separate hosts from permissions.

### All Submissions:

* [x] Have you tested your changes with the `test-page.html` file?
* [x] Have you added a short summary to the `CHANGELOG.md`, or actively decided that it's not worth mentioning?
