### PR TITLE
Switch back to persistent background script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Downgrade to Manifest v2 as persistent scripts are not supported in v3 (@LukeCz)
 
 ## [1.7.0] - 2024-10-19
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,13 @@
 {
   "description": "Disables Microsoft SafeLink protection by redirecting to the original URL instead of going through Microsoft",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "Disable Microsoft Safe Links",
   "version": "1.7.0",
   "homepage_url": "https://github.com/wtimme/firefox-remove-safelinks",
   "permissions": [
     "storage",
     "webRequest",
-    "webRequestBlocking"
-  ],
-  "host_permissions": [
+    "webRequestBlocking",
     "https://statics.teams.cdn.office.net/evergreen-assets/safelinks/1/atp-safelinks.html*",
     "https://safelinks.protection.outlook.com/*",
     "https://*.safelinks.protection.outlook.com/*",


### PR DESCRIPTION
### Introduction

Downgrade to manifest v2 as persistent scripts are not supported in v3.
Converting to non-persistent script (https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts#convert_to_non-persistent) seems to have a downside of not working in private mode. However even with v3 the API correctly splits permissions from URLs even though they are on the same list so moving to v3 is not necessary.

### All Submissions:

* [x] Have you tested your changes with the `test-page.html` file?
* [x] Have you added a short summary to the `CHANGELOG.md`, or actively decided that it's not worth mentioning?
